### PR TITLE
Add ESM build

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,14 @@
   },
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "files": [
     "LICENSE",
     "README.md",
@@ -40,7 +48,8 @@
     "lint:prettier": "prettier --check .",
     "format": "prettier --write .",
     "clean": "rm -rf dist",
-    "build": "npm run clean && tsc",
+    "build": "npm run clean && tsc && npm run build:esm",
+    "build:esm": "sed 's/module.exports =/export default/' dist/index.js > dist/index.mjs",
     "test": "ts-node test.ts"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "LICENSE",
     "README.md",
     "CHANGELOG.md",
-    "dist/index.js",
-    "dist/index.d.ts"
+    "dist"
   ],
   "scripts": {
     "pretest": "npm run lint",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "engines": {
     "node": ">=18.0.0"
   },
+  "sideEffects": false,
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "exports": {

--- a/test.ts
+++ b/test.ts
@@ -1,5 +1,5 @@
-import assert = require("node:assert/strict");
-import builder = require("./index");
+import assert from "node:assert/strict";
+import builder from "./index";
 
 const test = (
   message: string,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "include": ["index.ts"],
   "compilerOptions": {
     "declaration": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Hi 👋 

Would you consider distributing this library in ESM?
I'm adding here a minimal setup to create `index.mjs`.

Since you're using export assignments (`export = ...`) in the source code, we can't use `tsc --module esnext` to generate `index.mjs`. However, the code is small enough to simply use something like `sed` like in this PR.